### PR TITLE
install git regulatory.db the debian way

### DIFF
--- a/buildimg.sh
+++ b/buildimg.sh
@@ -196,10 +196,12 @@ if [[ ${board} != "bpi-r2pro" ]];then
 	echo "copy firmware files"
 	sudo cp -r firmware/* ${targetdir}/lib/firmware/
 
-	curl https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/plain/regulatory.db -o regulatory.db
-	curl https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/plain/regulatory.db.p7s -o regulatory.db.p7s
+	curl https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/plain/regulatory.db -o regulatory.db-git
+	curl https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/plain/regulatory.db.p7s -o regulatory.db.p7s-git
 
 	sudo cp -r regulatory.* ${targetdir}/lib/firmware/
+    sudo chroot $targetdir bash -c "update-alternatives --install /lib/firmware/regulatory.db regulatory.db /lib/firmware/regulatory.db-git 200 --slave /lib/firmware/regulatory.db.p7s regulatory.db.p7s /lib/firmware/regulatory.db.p7s-git"
+    sudo chroot $targetdir bash -c "update-alternatives --set regulatory.db /lib/firmware/regulatory.db-git"
 
 	if [[ ${board} == "bpi-r64" ]];then
 		echo "mt7615e" | sudo tee -a ${targetdir}/etc/modules


### PR DESCRIPTION
do not simply overwrite regulatory.db to avoid future conflicts with (re)install of wireless-regdb package