### PR TITLE
Fix ubuntu build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```sh
 ./buildimg.sh bpi-r3 bookworm
-./buildimg.sh bpi-r4 jammy
+./buildimg.sh bpi-r4 noble
 
 #use kernel 6.12 for r2 (normally 5.15 is used because of internal wifi support)
 ./buildimg.sh bpi-r2 bookworm 6.12

--- a/buildchroot.sh
+++ b/buildchroot.sh
@@ -10,7 +10,7 @@ distro=bookworm
 #ubuntu
 distro_ubuntu=(focal jammy noble)
 #name=ubuntu
-#distro=jammy #22.04
+#distro=noble #24.04
 
 #arch=armhf
 arch=arm64


### PR DESCRIPTION
Actual version of Ubuntu is noble. 
If you run `./buildimg.sh bpi-r4 jammy` it exits with error. 